### PR TITLE
Added file which should encompass global AM styles

### DIFF
--- a/frontend/src/styles/index.sass
+++ b/frontend/src/styles/index.sass
@@ -1,4 +1,5 @@
 @import 'theme'
+@import 'material'
 
 /* import these always the last */
 @import 'global'

--- a/frontend/src/styles/material.sass
+++ b/frontend/src/styles/material.sass
@@ -1,0 +1,8 @@
+/* Add styles for Angular Material components here */
+
+/* Example */
+/* Change the color of bar under active tab in mat-tab-group */
+/*
+ *.mat-tab-group.mat-primary .mat-ink-bar
+ *    background-color: red
+ */


### PR DESCRIPTION
Looking forward, `material.sass` could be split into separate files for convenience, one for each AM component.