### PR TITLE
Fixed #123 'No ability to put a space between words'

### DIFF
--- a/frontend/src/app/shared/constants/model-validation.ts
+++ b/frontend/src/app/shared/constants/model-validation.ts
@@ -1,3 +1,3 @@
 export const userNameRegex: string | RegExp = new RegExp('^[a-zA-Zа-яА-Я0-9- ]+$');
-export const meetingNameRegex = "^[A-Za-z0-9-']*$";
+export const meetingNameRegex = "^[A-Za-z0-9-' ]*$";
 export const naturalNumberRegex = '^[1-9][0-9]*$';


### PR DESCRIPTION
Fixes [#123 No ability to put a space between words](https://trello.com/c/Dmy0pUB8/123-no-ability-to-put-a-space-between-words). 

Allow spaces in meeting name.