### PR TITLE
[#179] fixed new availability slot bug

### DIFF
--- a/backend/EasyMeets.Core/EasyMeets.Core.BLL/Interfaces/ITeamService.cs
+++ b/backend/EasyMeets.Core/EasyMeets.Core.BLL/Interfaces/ITeamService.cs
@@ -1,5 +1,6 @@
 using EasyMeets.Core.Common.DTO.Team;
 using EasyMeets.Core.Common.DTO.UploadImage;
+using EasyMeets.Core.DAL.Entities;
 using Microsoft.AspNetCore.Http;
 namespace EasyMeets.Core.BLL.Interfaces;
 
@@ -8,7 +9,6 @@ public interface ITeamService
     Task<List<TeamDto>> GetCurrentUserTeams();
     Task<List<TeamDto>> GetCurrentUserAdminTeams();
     Task<TeamDto?> GetTeamAsync(long teamId);
-    Task<string> GenerateNewPageLinkAsync(long teamId, string teamName);
     Task<bool> ValidatePageLinkAsync(long? teamId, string pageLink);
     Task<TeamDto> CreateTeamAsync(NewTeamDto teamDto);
     Task UpdateTeamAsync(UpdateTeamDto team);

--- a/backend/EasyMeets.Core/EasyMeets.Core.BLL/Interfaces/ITeamSharedService.cs
+++ b/backend/EasyMeets.Core/EasyMeets.Core.BLL/Interfaces/ITeamSharedService.cs
@@ -1,0 +1,9 @@
+using EasyMeets.Core.DAL.Entities;
+
+namespace EasyMeets.Core.BLL.Interfaces;
+
+public interface ITeamSharedService
+{
+    Task CreateDefaultUsersTeamAsync(User user);
+    Task<string> GenerateNewPageLinkAsync(long teamId, string teamName);
+}

--- a/backend/EasyMeets.Core/EasyMeets.Core.BLL/Services/TeamService.cs
+++ b/backend/EasyMeets.Core/EasyMeets.Core.BLL/Services/TeamService.cs
@@ -11,9 +11,8 @@ namespace EasyMeets.Core.BLL.Services;
 
 public class TeamService : BaseService, ITeamService
 {
-
     private readonly IUserService _userService;
-    private IUploadFileService _uploadFileService;
+    private readonly IUploadFileService _uploadFileService;
     public TeamService(EasyMeetsCoreContext context, IMapper mapper, IUserService userService, IUploadFileService uploadFileService) : base(context, mapper)
     {
         _userService = userService;
@@ -24,23 +23,6 @@ public class TeamService : BaseService, ITeamService
     {
         var teamEntity = await GetTeamByIdAsync(teamId);
         return _mapper.Map<TeamDto>(teamEntity);
-    }
-
-    public async Task<string> GenerateNewPageLinkAsync(long teamId, string teamName)
-    {
-        if (!await _context.Teams.AnyAsync(t => t.Id != teamId && t.PageLink == teamName))
-        {
-            return teamName;
-        }
-
-        int index = 1;
-
-        while (await _context.Teams.AnyAsync(t => t.Id != teamId && t.PageLink == $"{teamName}{index}"))
-        {
-            index++;
-        }
-
-        return $"{teamName}{index}";
     }
 
     public async Task<bool> ValidatePageLinkAsync(long? teamId, string pageLink)

--- a/backend/EasyMeets.Core/EasyMeets.Core.BLL/Services/TeamSharedService.cs
+++ b/backend/EasyMeets.Core/EasyMeets.Core.BLL/Services/TeamSharedService.cs
@@ -1,0 +1,60 @@
+using AutoMapper;
+using EasyMeets.Core.BLL.Interfaces;
+using EasyMeets.Core.Common.DTO.Team;
+using EasyMeets.Core.Common.Enums;
+using EasyMeets.Core.DAL.Context;
+using EasyMeets.Core.DAL.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace EasyMeets.Core.BLL.Services;
+
+public class TeamSharedService : BaseService, ITeamSharedService
+{
+    public TeamSharedService(EasyMeetsCoreContext context, IMapper mapper) : base(context, mapper)
+    {
+    }
+
+    public async Task CreateDefaultUsersTeamAsync(User user)
+    {
+        var teamName = user.Name.Replace(" ", "") + "Team";
+        var teamDto = new TeamDto
+        {
+            Description = "",
+            Image = "",
+            Name = teamName,
+            PageLink = await GenerateNewPageLinkAsync(0, teamName),
+            TimeZone = user.TimeZone
+        };
+        
+        var team = _mapper.Map<Team>(teamDto);
+        var createdTeam = _context.Teams.Add(team).Entity;
+        await _context.SaveChangesAsync();
+        
+        var member = new TeamMember
+        {
+            Role = Role.Admin,
+            TeamId = createdTeam.Id,
+            UserId = user.Id,
+        };
+        
+        _context.TeamMembers.Add(member);
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task<string> GenerateNewPageLinkAsync(long teamId, string teamName)
+    {
+        if (!await _context.Teams.AnyAsync(t => t.Id != teamId && t.PageLink == teamName))
+        {
+            return teamName;
+        }
+
+        int index = 1;
+
+        while (await _context.Teams.AnyAsync(t => t.Id != teamId && t.PageLink == $"{teamName}{index}"))
+        {
+            index++;
+        }
+
+        return $"{teamName}{index}";
+    }
+}

--- a/backend/EasyMeets.Core/EasyMeets.Core.BLL/Services/UserService.cs
+++ b/backend/EasyMeets.Core/EasyMeets.Core.BLL/Services/UserService.cs
@@ -17,12 +17,15 @@ namespace EasyMeets.Core.BLL.Services
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly IZoomService _zoomService;
         private readonly IUploadFileService _uploadFileService;
+        private readonly ITeamSharedService _teamSharedService;
+        
         public UserService(EasyMeetsCoreContext context, IMapper mapper, IHttpContextAccessor httpContextAccessor,
-            IUploadFileService uploadFileService, IZoomService zoomService) : base(context, mapper)
+            IUploadFileService uploadFileService, IZoomService zoomService, ITeamSharedService teamSharedService) : base(context, mapper)
         {
             _httpContextAccessor = httpContextAccessor;
             _zoomService = zoomService;
             _uploadFileService = uploadFileService;
+            _teamSharedService = teamSharedService;
         }
 
         public async Task<UserDto> GetCurrentUserAsync()
@@ -62,8 +65,11 @@ namespace EasyMeets.Core.BLL.Services
         public async Task<UserDto> CreateUserPreferences(NewUserDto userDto)
         {
             var newUser = _mapper.Map<NewUserDto, User>(userDto);
-            _context.Users.Add(newUser);
+            var user = _context.Users.Add(newUser).Entity;
             await _context.SaveChangesAsync();
+
+            await _teamSharedService.CreateDefaultUsersTeamAsync(user);
+            
             return _mapper.Map<User, UserDto>(newUser);
         }
 

--- a/backend/EasyMeets.Core/EasyMeets.Core.WebAPI/Controllers/TeamController.cs
+++ b/backend/EasyMeets.Core/EasyMeets.Core.WebAPI/Controllers/TeamController.cs
@@ -11,9 +11,11 @@ namespace EasyMeets.Core.WebAPI.Controllers;
 public class TeamController : ControllerBase
 {
     private readonly ITeamService _teamService;
-    public TeamController(ITeamService teamService)
+    private readonly ITeamSharedService _sharedService;
+    public TeamController(ITeamService teamService, ITeamSharedService sharedService)
     {
         _teamService = teamService;
+        _sharedService = sharedService;
     }
 
     [HttpGet("{id}")]
@@ -25,7 +27,7 @@ public class TeamController : ControllerBase
     [HttpGet("newpagelink")]
     public async Task<ActionResult<string>> GenerateNewPageLinkAsync(long id, string teamname)
     {
-        return Ok(await _teamService.GenerateNewPageLinkAsync(id, teamname));
+        return Ok(await _sharedService.GenerateNewPageLinkAsync(id, teamname));
     }
     
     [HttpGet("user-teams")]

--- a/backend/EasyMeets.Core/EasyMeets.Core.WebAPI/Extentions/ServiceCollectionExtensions.cs
+++ b/backend/EasyMeets.Core/EasyMeets.Core.WebAPI/Extentions/ServiceCollectionExtensions.cs
@@ -31,6 +31,7 @@ namespace EasyMeets.Core.WebAPI.Extentions
             services.AddTransient<ICalendarsService, CalendarsService>();
             services.AddTransient<IMeetingService, MeetingService>();
             services.AddTransient<ITeamService, TeamService>();
+            services.AddTransient<ITeamSharedService, TeamSharedService>();
             services.AddTransient<IGoogleOAuthService, GoogleOAuthService>();
             services.AddTransient<IZoomService, ZoomService>();
             services.AddHttpClient<IZoomService, ZoomService>();

--- a/backend/EasyMeets.Core/EasyMeets.Core.WebAPI/appsettings.json
+++ b/backend/EasyMeets.Core/EasyMeets.Core.WebAPI/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "EasyMeetsCoreDBConnection": "Server=localhost;Database=EasyMeetsCoreDB;Trusted_Connection=True;"
+    "EasyMeetsCoreDBConnection": "Server=(localdb)\\MSSQLLocalDB;Database=EasyMeetsCoreDB;Trusted_Connection=True;"
   },
   "RabbitMQConfiguration": {
     "Uri": "amqp://guest:guest@localhost:5672",

--- a/backend/EasyMeets.Core/EasyMeets.Core.WebAPI/appsettings.json
+++ b/backend/EasyMeets.Core/EasyMeets.Core.WebAPI/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "EasyMeetsCoreDBConnection": "Server=(localdb)\\MSSQLLocalDB;Database=EasyMeetsCoreDB;Trusted_Connection=True;"
+    "EasyMeetsCoreDBConnection": "Server=localhost;Database=EasyMeetsCoreDB;Trusted_Connection=True;"
   },
   "RabbitMQConfiguration": {
     "Uri": "amqp://guest:guest@localhost:5672",


### PR DESCRIPTION
**Before:** when user didn't have any team, he couldn't create new availability slot.
**Now:** when user registers in our web-site, his default team is automatically created and he can create slots
**Important**: as you can see, we have injected IUserService in TeamService. And we can't inject ITeamService to UserService because it will cause cycle dependencies error. So, because of that, I've created new shared service.