### PR TITLE
[#195] fixed location name after creating slot

### DIFF
--- a/frontend/src/app/modules/availability/edit-slot/edit-availability-page/edit-availability-page.component.ts
+++ b/frontend/src/app/modules/availability/edit-slot/edit-availability-page/edit-availability-page.component.ts
@@ -9,6 +9,7 @@ import { NotificationService } from '@core/services/notification.service';
 import { SpinnerService } from '@core/services/spinner.service';
 import { NewAvailabilityComponent } from '@modules/availability/new-slot/new-availability/new-availability.component';
 import { deletionMessage } from '@shared/constants/shared-messages';
+import { LocationType } from '@shared/enums/locationType';
 import { Subscription } from 'rxjs';
 
 @Component({
@@ -44,11 +45,27 @@ export class EditAvailabilityPageComponent extends BaseComponent implements OnDe
                 .pipe(this.untilThis)
                 .subscribe((slotResponse) => {
                     this.slot = slotResponse;
+                    const locationName: string = this.locationTypeValues[+this.slot.locationType];
+
+                    this.slot.locationType = this.getLocation(locationName);
                     this.spinnerService.hide();
                 });
         });
 
         this.deleteEventSubscription = this.deleteEventEmitter.subscribe(() => this.deleteSlot());
+    }
+
+    locationTypeValues: string[] = Object.values(LocationType);
+
+    getLocation(name: string): LocationType {
+        switch (name) {
+            case 'Google Meet':
+                return LocationType.GoogleMeet;
+            case 'Office':
+                return LocationType.Office;
+            default:
+                return LocationType.Zoom;
+        }
     }
 
     public goToPage(pageName: string) {


### PR DESCRIPTION
When we gets slot from our backend, it can't transform to LocationType that we have on the frontend. The reason is that in database Location is a number and we send also number. But LocationType enum on the frontend keeps strings and our number-value from backend isn't string. So, because of that location was shown incorrect in "Meeting Location" after creating slot.
I've been searching better variant to figure out this bug, but for now the best what I came up with it's to create 1 additional function, that receive string and return LocationType for slot.