### PR TITLE
[#186] changed teams' names in menu

### DIFF
--- a/frontend/src/app/modules/header/header-item/header-item.component.html
+++ b/frontend/src/app/modules/header/header-item/header-item.component.html
@@ -16,7 +16,7 @@
         </nav>
 
         <button class="menu-team-btn" mat-button [matMenuTriggerFor]="menuTeam" *ngIf="teams.length; else newTeam">
-            <label class="current-team">{{ currentTeam?.name ?? '' }}</label>
+            <label>{{ currentTeam?.name ?? '' }}</label>
             <img src="assets/icons/angle-down.svg" alt="angle-down" />
         </button>
         <ng-template #newTeam>
@@ -25,15 +25,17 @@
                 <span> New Team</span>
             </button>
         </ng-template>
-        <mat-menu #menuTeam="matMenu">
-            <button mat-menu-item routerLink="#" *ngFor="let team of teams" (click)="changeTeam(team.id)">
-                <i class="fa-solid fa-people-group"></i>
-                <span class="team-name">{{ team.name }}</span>
-            </button>
-            <button class="mat-menu-btn" mat-menu-item routerLink="/settings/teams/new">
-                <i class="fa-solid fa-plus"></i>
-                <span>New Team</span>
-            </button>
+        <mat-menu #menuTeam="matMenu" xPosition="before">
+            <div class="menu-team-content">
+                <button mat-menu-item routerLink="#" *ngFor="let team of teams" (click)="changeTeam(team.id)">
+                    <i class="fa-solid fa-people-group"></i>
+                    <span class="team-name">{{ team.name }}</span>
+                </button>
+                <button class="mat-menu-btn" mat-menu-item routerLink="/settings/teams/new">
+                    <i class="fa-solid fa-plus"></i>
+                    <span>New Team</span>
+                </button>
+            </div>
         </mat-menu>
         <button class="avatar-btn" mat-icon-button [matMenuTriggerFor]="menuAvatar" disableRipple="true">
             <div class="avatar">

--- a/frontend/src/app/modules/header/header-item/header-item.component.html
+++ b/frontend/src/app/modules/header/header-item/header-item.component.html
@@ -1,6 +1,6 @@
 <header class="main-header">
     <div class="header-wrapper">
-        <img class="logo" src="assets/header/header-logo.svg"  alt="header-logo"/>
+        <img class="logo" src="assets/header/header-logo.svg" alt="header-logo" />
         <nav class="tab-panel" mat-tab-nav-bar>
             <a
                 mat-tab-link
@@ -16,8 +16,8 @@
         </nav>
 
         <button class="menu-team-btn" mat-button [matMenuTriggerFor]="menuTeam" *ngIf="teams.length; else newTeam">
-            <label>{{currentTeam?.name ?? ''}}</label>
-            <img src="assets/icons/angle-down.svg"  alt="angle-down"/>
+            <label class="current-team">{{ currentTeam?.name ?? '' }}</label>
+            <img src="assets/icons/angle-down.svg" alt="angle-down" />
         </button>
         <ng-template #newTeam>
             <button class="menu-team-btn" mat-button routerLink="/settings/teams/new">
@@ -28,7 +28,7 @@
         <mat-menu #menuTeam="matMenu">
             <button mat-menu-item routerLink="#" *ngFor="let team of teams" (click)="changeTeam(team.id)">
                 <i class="fa-solid fa-people-group"></i>
-                <span>{{team.name}}</span>
+                <span class="team-name">{{ team.name }}</span>
             </button>
             <button class="mat-menu-btn" mat-menu-item routerLink="/settings/teams/new">
                 <i class="fa-solid fa-plus"></i>

--- a/frontend/src/app/modules/header/header-item/header-item.component.sass
+++ b/frontend/src/app/modules/header/header-item/header-item.component.sass
@@ -127,5 +127,8 @@ label:hover
     text-overflow: ellipsis
 
 label
-    width: 150px
+    max-width: 150px
     display: inline-block
+
+.menu-team-content
+    padding: 0 5px

--- a/frontend/src/app/modules/header/header-item/header-item.component.sass
+++ b/frontend/src/app/modules/header/header-item/header-item.component.sass
@@ -23,7 +23,6 @@ header
         align-items: center
         justify-content: space-between
 
-
     .logo
         width: 176px
         height: 30px
@@ -60,8 +59,6 @@ header
     img
         width: 12px
         height: 6px
-
-
 
 .avatar
     display: flex
@@ -125,3 +122,10 @@ label:hover
         label
             display: none
 
+.team-name, label
+    overflow: hidden
+    text-overflow: ellipsis
+
+label
+    width: 150px
+    display: inline-block

--- a/frontend/src/styles/material.sass
+++ b/frontend/src/styles/material.sass
@@ -121,6 +121,3 @@ snack-bar-container
 .mat-form-field-infix
     padding: 0
     border-top: 0
-
-.mat-menu-panel
-    margin-left: 40px

--- a/frontend/src/styles/material.sass
+++ b/frontend/src/styles/material.sass
@@ -26,6 +26,7 @@
     font-size: 1em
     color: $pale-sky
     height: 30px
+    width: 150px
 
 .mat-menu-panel .mat-menu-item i
     margin: 0.5em

--- a/frontend/src/styles/material.sass
+++ b/frontend/src/styles/material.sass
@@ -121,3 +121,6 @@ snack-bar-container
 .mat-form-field-infix
     padding: 0
     border-top: 0
+
+.mat-menu-panel
+    margin-left: 40px


### PR DESCRIPTION
For now teams' names in header and menu are limited in width:
![Screenshot 2022-09-01 072058](https://user-images.githubusercontent.com/59260347/187831063-edd08348-1d65-4259-bfd2-b052ed640a12.png)


