### PR TITLE
#317 The bottom scroll should not be when adding a member

### DIFF
--- a/frontend/src/app/shared/components/team-members-window/team-members-window.component.sass
+++ b/frontend/src/app/shared/components/team-members-window/team-members-window.component.sass
@@ -51,6 +51,7 @@ hr
     margin-bottom: 15px
     height: 200px
     overflow-y: auto
+    overflow-x: hidden
     .user-info
         display: flex
         flex-direction: row


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/98499085/189681967-fa492e55-087a-4b4a-a0ae-79b44b47909f.png)

After:
![image](https://user-images.githubusercontent.com/98499085/189680860-53c4da07-2b1c-4866-9ccd-b96aeb1ed4c5.png)
