### PR TITLE
#321 Change form field min width in the calendars page

### DIFF
--- a/frontend/src/app/modules/calendars/calendars-page/calendars-page.component.sass
+++ b/frontend/src/app/modules/calendars/calendars-page/calendars-page.component.sass
@@ -67,7 +67,7 @@ button
     padding-left: 24px
 
 .table-container
-    overflow: auto
+    overflow-y: hidden
     width: 100%
 
 .mat-form-field-appearance-fill .mat-form-field-flex
@@ -81,8 +81,9 @@ mat-label
     font-size: 14px
     margin-top: 20px
 
-.table-container
-    overflow-y: hidden
+::ng-deep .table-container
+    .mat-form-field-infix
+        width: 80px
 
 ::ng-deep .mat-select-form .mat-select-value-text
     display: block


### PR DESCRIPTION
Сhanged mat-form-field width constraint of 180 px 
![image](https://user-images.githubusercontent.com/58224993/189916252-12ed0bfe-401e-41a2-91ac-e0a89304ae02.png)
