### PR TITLE
#421 Team name display fixed

### DIFF
--- a/frontend/src/app/modules/header/header-item/header-item.component.sass
+++ b/frontend/src/app/modules/header/header-item/header-item.component.sass
@@ -59,6 +59,10 @@ header
 .menu-team-btn
     display: flex
     justify-content: flex-end
+    span, label
+        text-overflow: ellipsis
+        white-space: nowrap
+        overflow: hidden
 
     img
         width: 12px
@@ -99,3 +103,9 @@ label
 
 .menu-team-content
     padding: 0 5px
+    button
+        max-width: 250px
+    span, label
+        text-overflow: ellipsis
+        white-space: nowrap
+        overflow: hidden


### PR DESCRIPTION
![Screenshot_934](https://user-images.githubusercontent.com/88149444/191939325-dfb36bf9-33a5-40f1-8bc3-8ccc14a75a42.png)
