### PR TITLE
[#428] the main information block is not flexible to small page sizes

### DIFF
--- a/frontend/src/app/modules/external-booking/external-booking-page/external-booking-page.component.sass
+++ b/frontend/src/app/modules/external-booking/external-booking-page/external-booking-page.component.sass
@@ -66,6 +66,8 @@
         height: 78px
         width: 78px
         clip-path: circle()
+    @media screen and (max-width: $desktop-min-width)
+        padding: 10px 10px
     .sidebar-list
         display: flex
         flex-direction: column
@@ -93,6 +95,8 @@
         .product-name
             font-size: 24px
             color: $logo-color
+        @media screen and (max-width: $desktop-min-width)
+            position: initial
 
     .welcome-message
         @media screen and (max-width: $desktop-min-width)


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/59260347/191963935-b8de6307-58a1-4d45-ab90-4ea8379c7d95.png)

after:
![image](https://user-images.githubusercontent.com/59260347/191963782-bf85f688-5eb9-477d-b6e1-de32a67d30b5.png)
